### PR TITLE
Exporting types from index.ts

### DIFF
--- a/src/Form.tsx
+++ b/src/Form.tsx
@@ -8,7 +8,7 @@ import { FormGroup } from "./FormGroup";
 import { FormLabel } from "./FormLabel";
 import { useGroupContext } from "./useGroupContext";
 
-type FormProps = {
+export type FormProps = {
     layout?: Layout;
     disabled?: boolean;
 } & React.HTMLAttributes<HTMLFormElement>;

--- a/src/FormElement.tsx
+++ b/src/FormElement.tsx
@@ -4,7 +4,7 @@ import { FormControl, FormControlProps } from "./FormControl";
 import { FormGroup, FormGroupProps } from "./FormGroup";
 import { FormLabel, FormLabelProps } from "./FormLabel";
 
-type Props = Omit<FormGroupProps, "as"> &
+export type FormElementProps = Omit<FormGroupProps, "as"> &
     FormControlProps & {
         label: FormLabelProps["children"];
     };
@@ -13,30 +13,36 @@ export const createElementComponent: (FormElems: {
     Control: typeof FormControl;
     Group: typeof FormGroup;
     Label: typeof FormLabel;
-}) => React.RefForwardingComponent<HTMLDivElement, Props> = ({ Control, Group, Label }) => {
-    const FormElement = React.forwardRef<HTMLDivElement, Props>((props: Props, ref) => {
-        // Group props
-        const { className, children, layout, disabled, required, ...afterGroup } = props;
+}) => React.RefForwardingComponent<HTMLDivElement, FormElementProps> = ({
+    Control,
+    Group,
+    Label,
+}) => {
+    const FormElement = React.forwardRef<HTMLDivElement, FormElementProps>(
+        (props: FormElementProps, ref) => {
+            // Group props
+            const { className, children, layout, disabled, required, ...afterGroup } = props;
 
-        // Label props
-        const { label, ...afterLabel } = afterGroup;
+            // Label props
+            const { label, ...afterLabel } = afterGroup;
 
-        // Control props
-        const { as, ...rest } = afterLabel;
+            // Control props
+            const { as, ...rest } = afterLabel;
 
-        return (
-            <Group
-                ref={ref}
-                className={className}
-                disabled={disabled}
-                layout={layout}
-                required={required}>
-                <Label>{label}</Label>
-                <Control as={as} {...rest}></Control>
-                {children}
-            </Group>
-        );
-    });
+            return (
+                <Group
+                    ref={ref}
+                    className={className}
+                    disabled={disabled}
+                    layout={layout}
+                    required={required}>
+                    <Label>{label}</Label>
+                    <Control as={as} {...rest}></Control>
+                    {children}
+                </Group>
+            );
+        }
+    );
 
     FormElement.displayName = "Form.Element";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,8 @@
 import { Form } from "./Form";
 
+export { FormProps } from "./Form";
+export { FormLabelProps } from "./FormLabel";
+export { FormGroupProps } from "./FormGroup";
+export { FormElementProps } from "./FormElement";
+
 export default Form;


### PR DESCRIPTION
It's nice to export types from the root index.ts so we can write stuff like:

```tsx
import { Form, FormProps } from "react-accessible-form";
```